### PR TITLE
Make main() non-async

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -144,8 +144,7 @@ pub struct Args {
     cmd: Command,
 }
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     let args = Args::from_args();
     setup_logger(args.json, args.level)?;
 


### PR DESCRIPTION
Fixes #14

Seems like it doesn't affect performance. The patched version still tries to use all cores.