### PR TITLE
Actually respect --disable-symlinks flag

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -6,6 +6,10 @@ on:
       - "*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 name: CI
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#32](https://github.com/Jake-Shadle/xwin/pull/32) fixed the `--disable-symlinks` flag to _actually_ not emit symlinks, which is needed if the target filesystem is case-insensitive.
+
 ## [0.1.8] - 2022-02-28
 ### Fixed
 - [PR#30](https://github.com/Jake-Shadle/xwin/pull/30) updated the indicatif pre-release as a workaround for `cargo install`'s [broken behavior](https://github.com/rust-lang/cargo/issues/7169). Thanks [@messense](https://github.com/messense)!

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -169,10 +169,13 @@ impl Ctx {
 
         let packages = std::sync::Arc::new(packages);
 
-        let splat_roots = if let crate::Ops::Splat(config) = &ops {
-            Some(crate::splat::prep_splat(self.clone(), config)?)
+        let (splat_roots, enable_symlinks) = if let crate::Ops::Splat(config) = &ops {
+            (
+                Some(crate::splat::prep_splat(self.clone(), config)?),
+                config.enable_symlinks,
+            )
         } else {
-            None
+            (None, false)
         };
 
         let mut results = Vec::new();
@@ -215,7 +218,9 @@ impl Ctx {
         let sdk_headers = sdk_headers.into_iter().flatten().collect();
 
         if let Some(roots) = splat_roots {
-            crate::splat::finalize_splat(&self, &roots, sdk_headers)?;
+            if enable_symlinks {
+                crate::splat::finalize_splat(&self, &roots, sdk_headers)?;
+            }
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn main() -> Result<(), Error> {
         } => xwin::Ops::Splat(xwin::SplatConfig {
             include_debug_libs,
             include_debug_symbols,
-            disable_symlinks,
+            enable_symlinks: !disable_symlinks,
             preserve_ms_arch_notation,
             copy,
             output: output.unwrap_or_else(|| ctx.work_dir.join("splat")),

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -29,7 +29,7 @@ fn verify_compiles() {
     let op = xwin::Ops::Splat(xwin::SplatConfig {
         include_debug_libs: false,
         include_debug_symbols: false,
-        disable_symlinks: false,
+        enable_symlinks: true,
         preserve_ms_arch_notation: false,
         copy: true,
         output: output_dir.clone(),

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -33,7 +33,7 @@ fn verify_deterministic() {
     let op = xwin::Ops::Splat(xwin::SplatConfig {
         include_debug_libs: false,
         include_debug_symbols: false,
-        disable_symlinks: false,
+        enable_symlinks: true,
         preserve_ms_arch_notation: false,
         copy: true,
         output: output_dir.clone(),


### PR DESCRIPTION
As mentioned in https://github.com/Jake-Shadle/xwin/issues/31#issuecomment-1053977672, we...didn't actually respect the `--disable-symlinks` flag which is problematic if the target filesystem is actually case-insensitive.