### PR TITLE
Update indicatif and pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#34](https://github.com/Jake-Shadle/xwin/pull/34) changed some code so that it is possible to compile and run for `x86_64-pc-windows-msvc`, though this target is not explicitly support. Thanks [@messense](https://github.com/messense)!
+- [PR#36](https://github.com/Jake-Shadle/xwin/pull/36) updated indicatif to `0.17.0-rc.6` and pinned it to fix [#35](https://github.com/Jake-Shadle/xwin/issues/35).
+
 ## [0.1.9] - 2022-02-28
 ### Fixed
 - [PR#32](https://github.com/Jake-Shadle/xwin/pull/32) fixed the `--disable-symlinks` flag to _actually_ not emit symlinks, which is needed if the target filesystem is case-insensitive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0-rc.5"
+version = "0.17.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a9b1bacd1a40927c953c5c4485089d8ecc9642cb03e7734eac8a74e8c5b508"
+checksum = "2946516aa80379c1e6ee9cfa75a7b2faf23f63690f44d682e7fecd0141bbcaf2"
 dependencies = [
  "console",
  "number_prefix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ flate2 = { version = "1.0", default-features = false, features = [
     "rust_backend",
 ] }
 # Pretty progress bars
-indicatif = "0.17.0-rc.5"
+indicatif = "=0.17.0-rc.6"
 # Decoding of MSI installer packages
 msi = "0.4"
 parking_lot = "0.12"


### PR DESCRIPTION
Updates `indicatif` to `0.17.0-rc.6` and pins it to get the fix for https://github.com/console-rs/indicatif/issues/387.

Resolves: #35 