### PR TITLE
Add symlink for `BaseTsd.h` in SDK headers.

### DIFF
--- a/src/splat.rs
+++ b/src/splat.rs
@@ -382,9 +382,11 @@ pub(crate) fn splat(
                                         anyhow::bail!("found duplicate relative path when hashed");
                                     }
 
-                                    // https://github.com/zeromq/libzmq/blob/3070a4b2461ec64129062907d915ed665d2ac126/src/precompiled.hpp#L73
                                     if let Some(additional_name) = match fname_str {
+                                        // https://github.com/zeromq/libzmq/blob/3070a4b2461ec64129062907d915ed665d2ac126/src/precompiled.hpp#L73
                                         "mstcpip.h" => Some("Mstcpip.h"),
+                                        // https://github.com/ponylang/ponyc/blob/8d41d6650b48b9733cd675df199588e6fccc6346/src/common/platform.h#L191
+                                        "basetsd.h" => Some("BaseTsd.h"),
                                         _ => None,
                                     } {
                                         tar.pop();

--- a/tests/expected.txt
+++ b/tests/expected.txt
@@ -2806,6 +2806,7 @@ sdk/include/cppwinrt/winrt/windows.web.http.headers.h @ f3c0219b319bb572
 sdk/include/cppwinrt/winrt/windows.web.syndication.h @ fba81df833d19d76
 sdk/include/cppwinrt/winrt/windows.web.ui.h @ a6e312bf6e06a36b
 sdk/include/cppwinrt/winrt/windows.web.ui.interop.h @ 671d7b874fad4dd8
+sdk/include/shared/BaseTsd.h => basetsd.h
 sdk/include/shared/BdaTypes.h => bdatypes.h
 sdk/include/shared/DriverSpecs.h => driverspecs.h
 sdk/include/shared/GenericUsbFnIoctl.h @ fc8133a69d8e2bb9


### PR DESCRIPTION
The capitalized version of this header is shown in Microsoft docs,
and it is used in places like the Pony runtime:
https://github.com/ponylang/ponyc/blob/8d41d6650b48b9733cd675df199588e6fccc6346/src/common/platform.h#L191

This commit adds a symlink for this file, in the same place in
the codebase where an special case already existed for another
header that is used by the `libzmq` project.