### PR TITLE
use `https_proxy` from env variables 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024a432ae760ab3bff924ad91ce1cfa52cb57ed16e1ef32d0d249cfee1a6c13"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",


### PR DESCRIPTION
We use `xwin` for cross-compilation on a CI/CD-runner behind our corporate proxy.

This PR enables `xwin` to download files behind a proxy by reading `https_proxy` environment variable and setting up proxy config when building `ureq::Agent` in `http_client()`