### PR TITLE
Add macos target

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,56 @@
+name: "Build xwin"
+
+inputs:
+  target:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        target: ${{ inputs.target }}
+    - name: Install musl toos
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y musl-tools
+      shell: bash
+    - name: Checkout
+      uses: actions/checkout@v2
+    - run: cargo fetch --target ${{ inputs.target }}
+      shell: bash
+    - name: Release build
+      shell: bash
+      run: |
+        cargo build --release --target ${{ inputs.target }}
+    - name: Package
+      shell: bash
+      run: |
+        name=xwin
+        tag=$(git describe --tags --abbrev=0)
+        target="${{ inputs.target }}"
+        release_name="$name-$tag-$target"
+        release_tar="${release_name}.tar.gz"
+        mkdir "$release_name"
+
+        strip "target/$target/release/$name"
+
+        cp "target/$target/release/$name" "$release_name/"
+        cp README.md LICENSE-APACHE LICENSE-MIT "$release_name/"
+        tar czvf "$release_tar" "$release_name"
+
+        rm -r "$release_name"
+        echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
+        echo "release_tar=$release_tar" >> $GITHUB_ENV
+        ls -al
+        pwd
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: |
+          ${{env.release_tar}}
+          ${{env.release_tar}}.sha256

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -117,45 +117,42 @@ jobs:
       - name: cargo publish check
         run: cargo publish --dry-run
 
-  release:
-    name: Release
+  linux:
+    name: Linux Build
     needs: [deny-check]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build
         with:
-          toolchain: stable
-          override: true
           target: x86_64-unknown-linux-musl
-      - name: Install musl tools
-        run: sudo apt-get install -y musl-tools
-      - name: Checkout
-        uses: actions/checkout@v2
-      - run: cargo fetch --target x86_64-unknown-linux-musl
-      - name: Release build
-        shell: bash
-        run: |
-          cargo build --release --target x86_64-unknown-linux-musl
-      - name: Package
-        shell: bash
-        run: |
-          name=xwin
-          tag=$(git describe --tags --abbrev=0)
-          target="x86_64-unknown-linux-musl"
-          release_name="$name-$tag-$target"
-          release_tar="${release_name}.tar.gz"
-          mkdir "$release_name"
 
-          strip "target/$target/release/$name"
+  macos:
+    name: MacOS Build
+    needs: [deny-check]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-12
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build
+        with:
+          target: ${{ matrix.platform.target }}
 
-          cp "target/$target/release/$name" "$release_name/"
-          cp README.md LICENSE-APACHE LICENSE-MIT "$release_name/"
-          tar czvf "$release_tar" "$release_name"
-
-          rm -r "$release_name"
-          echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ macos, linux ]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
       - name: Publish
         uses: softprops/action-gh-release@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .xwin-cache
 tests/xwin-test/target
 tests/xwin-test/Cargo.lock
+
+# IntelliJ cache
+.idea


### PR DESCRIPTION
I've been looking for the release for MacOS, for the cross build for clang + Mac. I've found some releases here https://github.com/messense/cargo-xwin, but it seems to be fork, so less trust. 
Never set up GitHub action, this is my first time) Just moved build action to separate file and added mac os target.

Example of release:
https://github.com/ZzEeKkAa/xwin/releases/tag/untagged-1cce06ead6861d7fecf6