### PR TITLE
optionally include active templating library

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -101,7 +101,7 @@ impl cmp::PartialOrd for ManifestItem {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Manifest {
     #[serde(rename = "channelItems")]
     channel_items: Vec<ManifestItem>,
@@ -157,7 +157,7 @@ pub fn get_package_manifest(
         progress,
     )?;
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     struct PkgManifest {
         packages: Vec<ManifestItem>,
     }

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -18,6 +18,7 @@ fn verify_compiles() {
         &pkg_manifest,
         xwin::Arch::X86_64 as u32,
         xwin::Variant::Desktop as u32,
+        false,
     )
     .unwrap();
 

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -22,6 +22,7 @@ fn verify_deterministic() {
         &pkg_manifest,
         xwin::Arch::X86_64 as u32,
         xwin::Variant::Desktop as u32,
+        false,
     )
     .unwrap();
 

--- a/tests/snapshots/xwin.snap
+++ b/tests/snapshots/xwin.snap
@@ -1,8 +1,6 @@
 ---
 source: src/main.rs
-assertion_line: 382
 expression: help_text
-
 ---
 xwin 0.0.0
 Jake Shadle <jake.shadle@embark-studios.com>
@@ -35,6 +33,10 @@ OPTIONS:
 
     -h, --help
             Print help information
+
+        --include-atl
+            Weheter to include the microsoft Active Template Library (ATL) in
+            the installation
 
         --json
             Output log messages as json


### PR DESCRIPTION
The microsoft active templating library (ATL) is used by some c++ libraries that rust crates might wish to link to (the lld linker for my usecase). This PR adds an optional flag that includes ATL with the installation.
I currently did not add any symlinks, because I am not sure if they are required (I personally do not work on windows), before merging it should be resolved whether any links are needed