### PR TITLE
Replace `ld` with `ld.lld` in dockerfile

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -58,7 +58,7 @@ fn verify_compiles() {
     }
 
     let mut cmd = std::process::Command::new("cargo");
-    cmd.args(&[
+    cmd.args([
         "build",
         "--target",
         "x86_64-pc-windows-msvc",
@@ -92,7 +92,7 @@ fn verify_compiles() {
     std::fs::remove_dir_all("tests/xwin-test/target").expect("failed to remove target dir");
 
     let mut cmd = std::process::Command::new("cargo");
-    cmd.args(&[
+    cmd.args([
         "build",
         "--target",
         "x86_64-pc-windows-msvc",

--- a/xwin.dockerfile
+++ b/xwin.dockerfile
@@ -36,9 +36,10 @@ RUN set -eux; \
     llvm-lib -v; \
     clang-cl -v; \
     lld-link --version; \
-    # Use clang instead of gcc when compiling binaries targeting the host (eg proc macros, build files)
+    # Use clang instead of gcc when compiling and linking binaries targeting the host (eg proc macros, build files)
     update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
     update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100; \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 100; \
     apt-get remove -y --auto-remove; \
     rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
When replacing the compilers with `clang(++)`, while leaving the default linker at gcc, it fails because it doesn't recognize (`ar`chives of) LLVM IR bitcode objects:

    = note: /usr/bin/ld: /tmp/cargo-install26EVLj/release/deps/libzstd_sys-054e18b4564e3c5f.rlib: error adding symbols: file format not recognized
            clang: error: linker command failed with exit code 1 (use -v to see invocation)

Solve this by also (suggesting to) replace `ld` with LLVM's `ld.lld`.
