### PR TITLE
Bump dockerfile xwin version to `0.2.9` and automate in `release.toml`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -7,4 +7,5 @@ pre-release-replacements = [
   { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
   { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate" },
   { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/Jake-Shadle/xwin/compare/{{tag_name}}...HEAD" },
+  { file = "xwin.dockerfile", search = "xwin_version=\"\\d+\\.\\d+\\.\\d+\";", replace = "xwin_version=\"{{version}}\";" },
 ]

--- a/xwin.dockerfile
+++ b/xwin.dockerfile
@@ -47,12 +47,12 @@ RUN set -eux; \
 RUN rustup target add x86_64-pc-windows-msvc
 
 RUN set -eux; \
-    xwin_version="0.1.6"; \
+    xwin_version="0.2.9"; \
     xwin_prefix="xwin-$xwin_version-x86_64-unknown-linux-musl"; \
     # Install xwin to cargo/bin via github release. Note you could also just use `cargo install xwin`.
     curl --fail -L https://github.com/Jake-Shadle/xwin/releases/download/$xwin_version/$xwin_prefix.tar.gz | tar -xzv -C /usr/local/cargo/bin --strip-components=1 $xwin_prefix/xwin; \
     # Splat the CRT and SDK files to /xwin/crt and /xwin/sdk respectively
-    xwin --accept-license 1 splat --output /xwin; \
+    xwin --accept-license splat --output /xwin; \
     # Remove unneeded files to reduce image size
     rm -rf .xwin-cache /usr/local/cargo/bin/xwin;
 


### PR DESCRIPTION
Update this exemplary `dockerfile` to the latest xwin release, and remove the `1` "truthy" flag from `--accept-license` which is now just a boolean flag based on precedence.

Testing `release.toml`, running `cargo release 0.2.9` in dry-run shows:

```diff
   Replacing in xwin.dockerfile
--- xwin.dockerfile     original
+++ xwin.dockerfile     replaced
@@ -49 +49 @@
-    xwin_version="0.1.6"; \
+    xwin_version="0.2.9"; \
```
