### PR TITLE
Use "fosskers/rs-versions" to determine the latest CRT and SDK versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +667,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1392,6 +1417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "versions"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee97e1d97bd593fb513912a07691b742361b3dd64ad56f2c694ea2dbfe0665d3"
+dependencies = [
+ "itertools",
+ "nom",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1627,7 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "ureq",
+ "versions",
  "walkdir",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 # Hashing
 twox-hash = "1.6"
+# Determine the latest CRT and SDK versions
+versions = "4.1.0"
 # Unpacking of VSIX "packages"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 


### PR DESCRIPTION
## Problem with 17.4.1 manifest

<https://github.com/Jake-Shadle/xwin/blob/5ece33c5df771221588faf6f5d81e59011ab1628/src/lib.rs#L342-L350>
The latest CRT version is obtained from a dependency of `Microsoft.VisualStudio.Product.BuildTools` package.
A dependency with a CRT version is expected to begin with `Microsoft.VisualStudio.Component.VC.` and end with `.x86.x64`.
The latest version is determined by string ordering.
In the current `17.4.1` version of the manifest, there is a dependency `Microsoft.VisualStudio.Component.VC.Modules.x86.x64`, so xwin determines that the latest CRT version is `Modules`.

Executing
```
xwin --accept-license --manifest-version=17 download
```
causes an error
```
Error: unable to find CRT headers item 'Microsoft.VC.Modules.CRT.Headers.base'
```
xwin can't find `Microsoft.VC.{crt_version}.CRT.Headers.base` package in the manifest because `{crt_version}` is `Modules`.



## Potential problem with string ordering

String ordering might fail on some version numbers,
e.g. if the dependencies are
```
Microsoft.VisualStudio.Component.VC.15.9.x86.x64
Microsoft.VisualStudio.Component.VC.15.10.x86.x64
```
the latest version will be determined as `15.9`.

<https://github.com/Jake-Shadle/xwin/blob/5ece33c5df771221588faf6f5d81e59011ab1628/src/lib.rs#L522-L526>
The latest SDK version is also determined by string ordering.



## List of existing versions from currently available manifests

Might be useful to determine if changes from this pull request are needed.
Looks like recent "CRT version" is just a concatenation of `14.*` real CRT version and manifest version (which matches Visual Studio version) and they usually increase simultaneously.
String ordering might work if there will be no major CRT version increase.

### CRT versions

`15.9.51` manifest (matching `Microsoft.VisualStudio.Component.VC.Tools.*`)
```
14.11
14.12
14.13
14.14
14.15
```

`16.11.21` manifest (matching `Microsoft.VisualStudio.Component.VC.*.x86.x64`)
```
14.20
14.21
14.22
14.23
14.24
14.25
14.26
14.27
14.28.16.9
14.28
14.29.16.10
```

`17.4.1` manifest (matching `Microsoft.VisualStudio.Component.VC.*.x86.x64`)
```
14.29.16.11
14.30.17.0
14.31.17.1
14.32.17.2
14.33.17.3
14.34.17.4
```



### SDK versions (matching `Win10SDK_*`)

`15.9.51` manifest
```
10.0.10586.212
10.0.14393.795
10.0.15063
10.0.16299
10.0.17134
10.0.17763
```

`16.11.21` manifest
```
10.0.16299
10.0.17134
10.0.17763
10.0.18362
10.0.19041
10.0.20348
```

`17.4.1` manifest
```
10.0.18362
10.0.19041
10.0.20348
```



## The solution

Use [versions](https://github.com/fosskers/rs-versions) crate to compare versions.
Real versions will take precedence over obvious non-versions because an alphanumeric is less than a numeric with rs-versions.

Why not other crates.

<https://github.com/timvisee/version-compare.git>
Only `PartialOrd` is implemented, `.max()` doesn't work, need to write `.max_by(|a, b| a.compare(b).ord().unwrap())`.

<https://github.com/dtolnay/semver.git>
Expects exactly 3 numbers separated by dots.