### PR TITLE
Add aarch64-unknown-linux-musl build

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -115,6 +115,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
           - os: macos-12
             target: x86_64-apple-darwin
           - os: macos-12
@@ -127,7 +129,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install musl tools
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds the 'aarch64-unknown-linux-musl' target to the matrix used in the release step. This will build an additional release artifact useable on aarch64 Linux machines.