### PR TITLE
fix: don't strip aarch64-unknown-linux-musl binary

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -166,7 +166,7 @@ jobs:
           release_tar="${release_name}.tar.gz"
           mkdir "$release_name"
 
-          if [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
+          if [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" || "${{ matrix.target }}" != "aarch64-unknown-linux-musl" ]; then
             strip "target/$target/release/$name"
           fi
 


### PR DESCRIPTION
My previous PR broke the release build since `strip` does not recognize the aarch64 binary (input format).

For now, I have disabled running `strip` on the aarch64 binary. If you have a better suggestion, feel free to amend or recommend.