### PR TITLE
Use `llvm-strip`

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -167,7 +167,7 @@ jobs:
           mkdir "$release_name"
 
           if [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
-            strip "target/$target/release/$name"
+            llvm-strip "target/$target/release/$name"
           fi
 
           cp "target/$target/release/$name" "$release_name/"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: |
           name=xwin
-          tag=$(git describe --tags --abbrev=0)
+          tag=$(git describe --tags --abbrev=0 --always)
           target="${{ matrix.target }}"
           release_name="$name-$tag-$target"
           release_tar="${release_name}.tar.gz"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -122,8 +122,8 @@ jobs:
 
   release:
     name: Release
-    needs: [deny-check]
-    if: startsWith(github.ref, 'refs/tags/')
+    # needs: [deny-check]
+    # if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         include:
@@ -181,10 +181,10 @@ jobs:
           else
             echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
           fi
-      - name: Publish
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          files: "xwin*"
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      # - name: Publish
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     draft: true
+      #     files: "xwin*"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -122,8 +122,8 @@ jobs:
 
   release:
     name: Release
-    # needs: [deny-check]
-    # if: startsWith(github.ref, 'refs/tags/')
+    needs: [deny-check]
+    if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         include:
@@ -165,7 +165,7 @@ jobs:
         shell: bash
         run: |
           name=xwin
-          tag=$(git describe --tags --abbrev=0 --always)
+          tag=$(git describe --tags --abbrev=0)
           target="${{ matrix.target }}"
           release_name="$name-$tag-$target"
           release_tar="${release_name}.tar.gz"
@@ -186,10 +186,10 @@ jobs:
           else
             echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
           fi
-      # - name: Publish
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     draft: true
-      #     files: "xwin*"
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: "xwin*"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -129,14 +129,19 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
+            strip: llvm-strip
           - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
+            strip: llvm-strip
           - os: macos-12
             target: x86_64-apple-darwin
+            strip: strip
           - os: macos-12
             target: aarch64-apple-darwin
+            strip: strip
           - os: windows-2022
             target: x86_64-pc-windows-msvc
+            strip: ""
     runs-on: ${{ matrix.os }}
     env:
       CC_aarch64_unknown_linux_musl: clang
@@ -166,8 +171,8 @@ jobs:
           release_tar="${release_name}.tar.gz"
           mkdir "$release_name"
 
-          if [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
-            llvm-strip "target/$target/release/$name"
+          if [ ! -z "${{ matrix.strip }}" ]; then
+            ${{ matrix.strip }} "target/$target/release/$name"
           fi
 
           cp "target/$target/release/$name" "$release_name/"


### PR DESCRIPTION
- Use llvm-strip instead of strip
- Temporarily run release in PR to ensure it runs correctly

Closes: #89 