### PR TITLE
Fix: Provide timeouts for reading from sockets

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::{
     splat::SdkHeaders,
     util::{ProgressTarget, Sha256},
@@ -29,6 +31,8 @@ impl Ctx {
             use std::sync::Arc;
             let mut builder =
                 ureq::builder().tls_connector(Arc::new(native_tls_crate::TlsConnector::new()?));
+            // Have socket reads time out after a minute to catch stalled connections
+            builder = builder.timeout_read(Duration::from_secs(60));
             if let Ok(proxy) = std::env::var("https_proxy") {
                 let proxy = ureq::Proxy::new(proxy)?;
                 builder = builder.proxy(proxy);
@@ -39,6 +43,8 @@ impl Ctx {
         #[cfg(not(feature = "native-tls"))]
         {
             let mut builder = ureq::builder();
+            // Have socket reads time out after a minute to catch stalled connections
+            builder = builder.timeout_read(Duration::from_secs(60));
             if let Ok(proxy) = std::env::var("https_proxy") {
                 let proxy = ureq::Proxy::new(proxy)?;
                 builder = builder.proxy(proxy);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -35,10 +35,10 @@ impl Ctx {
         }
 
         // Allow user to specify timeout values in the case of bad/slow proxies
-        // or MS itself being terrible
-        if let Some(timeout) = read_timeout {
-            builder = builder.timeout_read(timeout);
-        }
+        // or MS itself being terrible, but default to a minute, which is _far_
+        // more than it should take in normal situations, as by default ureq
+        // sets no timeout on the response
+        builder = builder.timeout_read(read_timeout.unwrap_or(Duration::from_secs(60)));
 
         if let Ok(proxy) = std::env::var("https_proxy") {
             let proxy = ureq::Proxy::new(proxy)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ pub struct Args {
     /// Whether to include the Active Template Library (ATL) in the installation
     #[arg(long)]
     include_atl: bool,
-    /// Specifies a timeout for how long a single download is allowed to take. The default is no timeout.
+    /// Specifies a timeout for how long a single download is allowed to take. The default is 60s.
     #[arg(short, long, value_parser = parse_duration)]
     timeout: Option<Duration>,
     /// The architectures to include

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -3,6 +3,7 @@ fn verify_compiles() {
     let ctx = xwin::Ctx::with_dir(
         xwin::PathBuf::from(".xwin-cache/compile-test"),
         xwin::util::ProgressTarget::Hidden,
+        None,
     )
     .unwrap();
 

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -6,6 +6,7 @@ fn verify_deterministic() {
     let ctx = xwin::Ctx::with_dir(
         PathBuf::from(".xwin-cache/deterministic"),
         xwin::util::ProgressTarget::Hidden,
+        None,
     )
     .unwrap();
 

--- a/tests/snapshots/xwin.snap
+++ b/tests/snapshots/xwin.snap
@@ -60,6 +60,10 @@ Options:
           Whether to include the Active Template Library (ATL) in the
           installation
 
+  -t, --timeout <TIMEOUT>
+          Specifies a timeout for how long a single download is allowed to take.
+          The default is no timeout
+
       --arch <ARCH>
           The architectures to include
           

--- a/tests/snapshots/xwin.snap
+++ b/tests/snapshots/xwin.snap
@@ -62,7 +62,7 @@ Options:
 
   -t, --timeout <TIMEOUT>
           Specifies a timeout for how long a single download is allowed to take.
-          The default is no timeout
+          The default is 60s
 
       --arch <ARCH>
           The architectures to include


### PR DESCRIPTION
When Microsoft's CDNs are having a bad day, or when a user has limited bandwidth, the download process can stall and die permanently.

This PR allows xwin to recognise when this has happened and do something about it. Currently that's to fail gracefully, allowing the user to retry.