### PR TITLE
README: Copy `splat` documentation and describe `--output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Decompresses all of the downloaded package contents to disk. `download` is run a
 
 ### `xwin splat`
 
+Fixes the packages to prune unneeded files and adds symlinks to address file casing issues and then spalts the final artifacts into directories. This is the main command you will want to run as it also `download`s and `unpack`s automatically, providing the desired headers at the path specified to `--output` (`./.xwin-cache/splat`).
+
 * `--copy` - Copies files from the unpack directory to the splat directory instead of moving them, which preserves the original unpack directories but increases overall execution time and disk usage.
 * `--disable-symlinks` - By default, symlinks are added to both the CRT and WindowsSDK to address casing issues in general usage. For example, if you are compiling C/C++ code that does `#include <windows.h>`, it will break on a case-sensitive file system, as the actual path in the WindowsSDK is `Windows.h`. This also applies even if the C/C++ you are compiling uses correct casing for all CRT/SDK includes, as the internal headers also use incorrect casing in most cases
 * `--include-debug-libs` - The MSVCRT includes (non-redistributable) debug versions of the various libs that are generally uninteresting to keep for most usage
 * `--include-debug-symbols` - The MSVCRT includes PDB (debug symbols) files for several of the libraries that are generally uninteresting to keep for most usage
 * `--preserve-ms-arch-notation` - By default, we convert the MS specific `x64`, `arm`, and `arm64` target architectures to the more canonical `x86_64`, `aarch`, and `aarch64` of LLVM etc when creating directories/names. Passing this flag will preserve the MS names for those targets
+* `--output` - The root output directory. Defaults to `./.xwin-cache/splat` if not specified
 
 This moves all of the unpacked files which aren't pruned to their canonical locations under a root directory, for example here is what an `x86_64` `Desktop` splat looks like. `unpack` is run automatically as needed.
 


### PR DESCRIPTION
It took a while to figure out how to use this tool, when it's not immediately obvious from the readme alone that `xwin splat --output` is the command that most users will likely want to use to extract all the headers, after which they are ready to cross-compile with MSVC.

Note that I have added the setup from the blog / `xwin.dockerfile` locally to my `~/.cargo/config.toml` via `[env]` and `[target.x86_64-pc-windows-msvc]`.  The `[env]` obviously only works for C/C++ code compiled within Rust / `cargo` projects and not system-wide, but for example setting `rustflags` via `[target.*]` allows it to be merged with other target-specific `rustflags` in project-specific `./.cargo/config.toml` rather than being mutually exlusive with the `RUSTFLAGS` env var: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags.  Is it worth documenting this setup somewhere?
