### PR TITLE
Default to manifest 17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,12 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 insta = "1.12"
 walkdir = "2.3"
+
+[profile.dev.package.insta]
+opt-level = 3
+
+[profile.dev.package.similar]
+opt-level = 3
+
+[profile.dev.package.sha2]
+opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ pub struct Args {
     #[arg(long, conflicts_with_all = &["manifest_version", "channel"])]
     manifest: Option<PathBuf>,
     /// The manifest version to retrieve
-    #[arg(long, default_value = "16")]
+    #[arg(long, default_value = "17")]
     manifest_version: String,
     /// The product channel to use.
     #[arg(long, default_value = "release")]

--- a/src/splat.rs
+++ b/src/splat.rs
@@ -627,18 +627,38 @@ pub(crate) fn finalize_splat(
         path: PathBuf,
     }
 
+    fn compare_hashes(existing: &Header<'_>, new: (&SdkHeaders, &Path)) -> anyhow::Result<()> {
+        use crate::util::Sha256;
+
+        let existing_path = &existing.path;
+        let new_path = new.1;
+
+        let existing_hash = Sha256::digest(&std::fs::read(existing_path)?);
+        let new_hash = Sha256::digest(&std::fs::read(new_path)?);
+
+        anyhow::ensure!(
+            existing_hash == new_hash,
+            "2 files with same relative path were not equal: '{existing_path}' != '{new_path}'"
+        );
+
+        Ok(())
+    }
+
     for hdrs in &sdk_headers {
         for (k, v) in &hdrs.inner {
-            let existing = files.insert(
-                k,
-                Header {
-                    root: hdrs,
-                    path: v.clone(),
-                },
-            );
-
-            if let Some(existing) = existing {
-                panic!("already have {} matching {v}", existing.path);
+            if let Some(existing) = files.get(k) {
+                // We already have a file with the same path, if they're the same
+                // as each other it's fine, but if they differ we have an issue
+                compare_hashes(existing, (&hdrs, v))?;
+                tracing::debug!("skipped {v}, a matching path already exists");
+            } else {
+                files.insert(
+                    k,
+                    Header {
+                        root: hdrs,
+                        path: v.clone(),
+                    },
+                );
             }
         }
     }

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -11,7 +11,17 @@ fn verify_compiles() {
 
     let hidden = indicatif::ProgressBar::hidden();
 
-    let manifest = xwin::manifest::get_manifest(&ctx, "17", "release", hidden.clone()).unwrap();
+    // TODO: Bump to CI to 17 once github actions isn't using an ancient version,
+    // we could install in the action run, but not really worth it since I can
+    // test locally
+    let manifest_version = if std::env::var_os("CI").is_some() {
+        "16"
+    } else {
+        "17"
+    };
+
+    let manifest =
+        xwin::manifest::get_manifest(&ctx, manifest_version, "release", hidden.clone()).unwrap();
     let pkg_manifest =
         xwin::manifest::get_package_manifest(&ctx, &manifest, hidden.clone()).unwrap();
 

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -11,7 +11,7 @@ fn verify_compiles() {
 
     let hidden = indicatif::ProgressBar::hidden();
 
-    let manifest = xwin::manifest::get_manifest(&ctx, "16", "release", hidden.clone()).unwrap();
+    let manifest = xwin::manifest::get_manifest(&ctx, "17", "release", hidden.clone()).unwrap();
     let pkg_manifest =
         xwin::manifest::get_package_manifest(&ctx, &manifest, hidden.clone()).unwrap();
 

--- a/tests/snapshots/xwin.snap
+++ b/tests/snapshots/xwin.snap
@@ -49,7 +49,7 @@ Options:
       --manifest-version <MANIFEST_VERSION>
           The manifest version to retrieve
           
-          [default: 16]
+          [default: 17]
 
       --channel <CHANNEL>
           The product channel to use


### PR DESCRIPTION
This resolves an issue where there is _one_ (SIGH) file that exists in both the regular SDK headers and the Store headers. This just ensures that if a matching relative path is found, that the checksums of the files match exactly.

Resolves: #92 