### PR TITLE
Also create symlinks when running on Windows

### DIFF
--- a/src/splat.rs
+++ b/src/splat.rs
@@ -605,8 +605,12 @@ fn symlink(original: &str, link: &Path) -> Result<(), Error> {
 }
 
 #[cfg(windows)]
-fn symlink(_original: &str, _link: &Path) -> Result<(), Error> {
-    Ok(())
+fn symlink(original: &str, link: &Path) -> Result<(), Error> {
+    if std::fs::metadata(original)?.is_dir() {
+        std::os::windows::fs::symlink_dir(original, link)
+    } else {
+        std::os::windows::fs::symlink_file(original, link)
+    }.with_context(|| format!("unable to symlink from {link} to {original}"))
 }
 
 pub(crate) fn finalize_splat(


### PR DESCRIPTION
The code used to ignore symlinks on Windows, breaking support for clang-cl. I have added code to handle them, however this might change the behaviour of the application as creating symlinks on Windows requires the `SeCreateSymbolicLinkPrivilege` privilege (meaning the user needs to be Administrator or have Developer Mode enabled).

In my opinion, users with no such privilege should pass the `--disable-symlinks` flag (or maybe make that the default on Windows?)