### PR TITLE
Only symlink certain directories on Windows

### DIFF
--- a/src/splat.rs
+++ b/src/splat.rs
@@ -677,7 +677,7 @@ pub(crate) fn splat(
                 // Multiple architectures both have a lib dir,
                 // but we only need to create this symlink once.
                 if !versioned_linkname.exists() {
-                    symlink(".", &versioned_linkname)?;
+                    crate::symlink_on_windows_too(".", &versioned_linkname)?;
                 }
 
                 // https://github.com/llvm/llvm-project/blob/release/14.x/clang/lib/Driver/ToolChains/MSVC.cpp#L1102
@@ -698,7 +698,7 @@ pub(crate) fn splat(
                 // Desktop and Store variants both have an include dir,
                 // but we only need to create this symlink once.
                 if !versioned_linkname.exists() {
-                    symlink(".", &versioned_linkname)?;
+                    crate::symlink_on_windows_too(".", &versioned_linkname)?;
                 }
 
                 // https://github.com/llvm/llvm-project/blob/release/14.x/clang/lib/Driver/ToolChains/MSVC.cpp#L1340-L1346


### PR DESCRIPTION
Symlinking on Windows was completely broken as you can't symlink a file or directory with the same case-insensitive name, which is almost 100% how symlinks are used in this project. The exception are the versioned symlinks that point to `.` so that the compiles transparently work when using the clang-cl options that do version lookups instead of specifying each include path manually. This wasn't caught because this project does no testing on Windows since it was never the goal of the project and I'd rather avoid adding CI for it but if people keep using it on Windows that may need to change.

Resolves: #107 