### PR TITLE
Remove HTTP client creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,10 @@ exclude = [
 [features]
 # By default we use rustls for TLS
 default = ["rustls-tls"]
-rustls-tls = ["ureq/tls", "rustls-pemfile", "rustls"]
+rustls-tls = ["ureq/tls", "rustls"]
 # If this feature is enabled we instead use the native TLS implementation for the
 # target platform
-native-tls = [
-    "ureq/native-tls",
-    "native-tls-crate/vendored",
-    "rustls-pemfile",
-]
+native-tls = ["ureq/native-tls", "native-tls-crate/vendored"]
 
 [dependencies]
 # Easy errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod util;
 pub use ctx::Ctx;
 pub use minimize::MinimizeConfig;
 pub use splat::SplatConfig;
+pub use ureq;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Arch {

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -3,7 +3,7 @@ fn verify_compiles() {
     let ctx = xwin::Ctx::with_dir(
         xwin::PathBuf::from(".xwin-cache/compile-test"),
         xwin::util::ProgressTarget::Hidden,
-        None,
+        ureq::agent(),
     )
     .unwrap();
 
@@ -141,7 +141,7 @@ fn verify_compiles_minimized() {
     let ctx = xwin::Ctx::with_dir(
         xwin::PathBuf::from(".xwin-cache/compile-test-minimized"),
         xwin::util::ProgressTarget::Hidden,
-        None,
+        ureq::agent(),
     )
     .unwrap();
 

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -6,7 +6,7 @@ fn verify_deterministic() {
     let ctx = xwin::Ctx::with_dir(
         PathBuf::from(".xwin-cache/deterministic"),
         xwin::util::ProgressTarget::Hidden,
-        None,
+        ureq::agent(),
     )
     .unwrap();
 

--- a/tests/snapshots/xwin.snap
+++ b/tests/snapshots/xwin.snap
@@ -75,8 +75,14 @@ Options:
           installation
 
   -t, --timeout <TIMEOUT>
-          Specifies a timeout for how long a single download is allowed to take.
-          The default is 60s
+          Specifies a timeout for how long a single download is allowed to take
+          
+          [default: 60s]
+
+      --https-proxy <HTTPS_PROXY>
+          An HTTPS proxy to use
+          
+          [env: HTTPS_PROXY]
 
       --arch <ARCH>
           The architectures to include


### PR DESCRIPTION
After #109 and #104 (and #50) I've decided to change the structure of Ctx to force users to pass in their own `ureq::Agent` that is configured how they want it to be, rather than adding more and more customization into the library itself. `xwin` was never intended as a library, but since people are using it that way, I don't think it's a good idea to have the HTTP client customization in the library, especially since it's reading environment variables which IMO is not something libraries should do in most cases. This is a bit unfortunate since it means callers have to have their own code if they want to customize, but it means this crate is simpler, and caller's are free to make whatever decisions they want (other than HTTP client, but that's something that can be done later).