### PR TITLE
Use mimalloc in musl builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +631,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1662,6 +1681,7 @@ dependencies = [
  "indicatif",
  "insta",
  "memchr",
+ "mimalloc",
  "msi",
  "native-tls",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ walkdir = "2.3"
 # Unpacking of VSIX "packages"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
+[target.'cfg(target_env = "musl")'.dependencies]
+# Faster allocator for musl builds
+mimalloc = { version = "*", default-features = false }
+
 [dev-dependencies]
 insta = "1.12"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+#[cfg(target_env = "musl")]
+use mimalloc::MiMalloc;
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 use anyhow::{Context as _, Error};
 use camino::Utf8PathBuf as PathBuf;
 use clap::builder::{PossibleValuesParser, TypedValueParser as _};


### PR DESCRIPTION
Twice speed up musl binary.
On i9-9900K `xwin --include-atl --accept-license --manifest-version 17 splat` from 43 seconds goes down to 22 (with  .xwin-cache pre-populated).
It is still slower compared to system allocator build (~15 secs on glibc 2.39) but is an improvement nevertheless.
