### PR TITLE
Add --use-winsysroot-style option to splat

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Fixes the packages to prune unneeded files and adds symlinks to address file cas
 * `--include-debug-libs` - The MSVCRT includes (non-redistributable) debug versions of the various libs that are generally uninteresting to keep for most usage
 * `--include-debug-symbols` - The MSVCRT includes PDB (debug symbols) files for several of the libraries that are generally uninteresting to keep for most usage
 * `--preserve-ms-arch-notation` - By default, we convert the MS specific `x64`, `arm`, and `arm64` target architectures to the more canonical `x86_64`, `aarch`, and `aarch64` of LLVM etc when creating directories/names. Passing this flag will preserve the MS names for those targets
+* `--use-winsysroot-style` - Use the /winsysroot layout, so that clang-cl's /winsysroot flag can be used with the output, rather than needing both -vctoolsdir and -winsdkdir. You will likely also want to use --preserve-ms-arch-notation and --disable-symlinks for use with clang-cl on Windows.
 * `--output` - The root output directory. Defaults to `./.xwin-cache/splat` if not specified
 * `--map` - An optional [map](#map-file) file used to configure what files are splatted, and any additional symlinks to create.
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -164,6 +164,7 @@ impl Ctx {
         self: std::sync::Arc<Self>,
         packages: std::collections::BTreeMap<String, crate::manifest::ManifestItem>,
         payloads: Vec<WorkItem>,
+        crt_version: String,
         sdk_version: String,
         arches: u32,
         variants: u32,
@@ -179,20 +180,21 @@ impl Ctx {
 
         let splat_config = match &ops {
             crate::Ops::Splat(config) => {
-                let splat_roots = crate::splat::prep_splat(self.clone(), &config.output)?;
+                let splat_roots = crate::splat::prep_splat(self.clone(), &config.output, &crt_version, config.use_winsysroot_style)?;
                 let mut config = config.clone();
                 config.output = splat_roots.root.clone();
 
                 Some((splat_roots, config))
             }
             crate::Ops::Minimize(config) => {
-                let splat_roots = crate::splat::prep_splat(self.clone(), &config.splat_output)?;
+                let splat_roots = crate::splat::prep_splat(self.clone(), &config.splat_output, &crt_version, config.use_winsysroot_style)?;
 
                 let config = crate::SplatConfig {
                     preserve_ms_arch_notation: config.preserve_ms_arch_notation,
                     include_debug_libs: config.include_debug_libs,
                     include_debug_symbols: config.include_debug_symbols,
                     enable_symlinks: config.enable_symlinks,
+                    use_winsysroot_style: config.use_winsysroot_style,
                     output: splat_roots.root.clone(),
                     map: Some(config.map.clone()),
                     copy: config.copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ pub enum PayloadKind {
 }
 
 pub struct PrunedPackageList {
+    pub crt_version: String,
     pub sdk_version: String,
     pub payloads: Vec<Payload>,
 }
@@ -204,7 +205,7 @@ pub fn prune_pkg_list(
     let pkgs = &pkg_manifest.packages;
     let mut payloads = Vec::new();
 
-    get_crt(
+    let crt_version = get_crt(
         pkgs,
         arches,
         variants,
@@ -215,6 +216,7 @@ pub fn prune_pkg_list(
     let sdk_version = get_sdk(pkgs, arches, sdk_version, &mut payloads)?;
 
     Ok(PrunedPackageList {
+        crt_version,
         sdk_version,
         payloads,
     })
@@ -227,7 +229,7 @@ fn get_crt(
     pruned: &mut Vec<Payload>,
     include_atl: bool,
     crt_version: Option<String>,
-) -> Result<(), Error> {
+) -> Result<String, Error> {
     fn to_payload(mi: &manifest::ManifestItem, payload: &manifest::Payload) -> Payload {
         // These are really the only two we care about
         let kind = if mi.id.contains("Headers") {
@@ -375,7 +377,7 @@ fn get_crt(
         }
     }
 
-    Ok(())
+    Ok(crt_version)
 }
 
 fn get_atl(

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,12 @@ pub struct SplatOptions {
     /// Passing this flag will preserve the MS names for those targets.
     #[arg(long)]
     preserve_ms_arch_notation: bool,
+    /// Use the /winsysroot layout, so that clang-cl's /winsysroot flag can be
+    /// used with the output, rather than needing both -vctoolsdir and
+    /// -winsdkdir. You will likely also want to use --preserve-ms-arch-notation
+    /// and --disable-symlinks for use with clang-cl on Windows.
+    #[arg(long)]
+    use_winsysroot_style: bool,
 }
 
 #[derive(Subcommand)]
@@ -331,6 +337,7 @@ fn main() -> Result<(), Error> {
             include_debug_symbols: options.include_debug_symbols,
             enable_symlinks: !options.disable_symlinks,
             preserve_ms_arch_notation: options.preserve_ms_arch_notation,
+            use_winsysroot_style: options.use_winsysroot_style,
             copy,
             map,
             output: output.unwrap_or_else(|| ctx.work_dir.join("splat")),
@@ -349,6 +356,7 @@ fn main() -> Result<(), Error> {
             include_debug_symbols: options.include_debug_symbols,
             enable_symlinks: !options.disable_symlinks,
             preserve_ms_arch_notation: options.preserve_ms_arch_notation,
+            use_winsysroot_style: options.use_winsysroot_style,
             splat_output: output.unwrap_or_else(|| ctx.work_dir.join("splat")),
             copy,
             minimize_output,
@@ -419,7 +427,7 @@ fn main() -> Result<(), Error> {
     mp.set_move_cursor(true);
 
     let res = std::thread::spawn(move || {
-        ctx.execute(pkgs, work_items, pruned.sdk_version, arches, variants, op)
+        ctx.execute(pkgs, work_items, pruned.crt_version, pruned.sdk_version, arches, variants, op)
     })
     .join();
 

--- a/src/minimize.rs
+++ b/src/minimize.rs
@@ -5,6 +5,7 @@ pub struct MinimizeConfig {
     pub include_debug_libs: bool,
     pub include_debug_symbols: bool,
     pub enable_symlinks: bool,
+    pub use_winsysroot_style: bool,
     pub preserve_ms_arch_notation: bool,
     pub splat_output: PathBuf,
     pub copy: bool,

--- a/tests/compiles.rs
+++ b/tests/compiles.rs
@@ -45,6 +45,7 @@ fn verify_compiles() {
         include_debug_symbols: false,
         enable_symlinks: true,
         preserve_ms_arch_notation: false,
+        use_winsysroot_style: false,
         map: None,
         copy: true,
         output: output_dir.clone(),
@@ -60,6 +61,7 @@ fn verify_compiles() {
                 payload: std::sync::Arc::new(payload),
             })
             .collect(),
+        pruned.crt_version,
         pruned.sdk_version,
         xwin::Arch::X86_64 as u32,
         xwin::Variant::Desktop as u32,
@@ -190,6 +192,7 @@ fn verify_compiles_minimized() {
         include_debug_symbols: false,
         enable_symlinks: true,
         preserve_ms_arch_notation: false,
+        use_winsysroot_style: false,
         map: map_path.clone(),
         copy: true,
         splat_output: output_dir.clone(),
@@ -209,6 +212,7 @@ fn verify_compiles_minimized() {
                 payload: std::sync::Arc::new(payload),
             })
             .collect(),
+        pruned.crt_version,
         pruned.sdk_version,
         xwin::Arch::X86_64 as u32,
         xwin::Variant::Desktop as u32,

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -39,6 +39,7 @@ fn verify_deterministic() {
         include_debug_symbols: false,
         enable_symlinks: true,
         preserve_ms_arch_notation: false,
+        use_winsysroot_style: false,
         map: None,
         copy: true,
         output: output_dir.clone(),
@@ -54,6 +55,7 @@ fn verify_deterministic() {
                 payload: std::sync::Arc::new(payload),
             })
             .collect(),
+        pruned.crt_version,
         pruned.sdk_version,
         xwin::Arch::X86_64 as u32,
         xwin::Variant::Desktop as u32,

--- a/tests/snapshots/xwin-minimize.snap
+++ b/tests/snapshots/xwin-minimize.snap
@@ -40,6 +40,13 @@ Options:
           
           Passing this flag will preserve the MS names for those targets.
 
+      --use-winsysroot-style
+          Use the /winsysroot layout, so that clang-cl's /winsysroot flag can be
+          used with the output, rather than needing both -vctoolsdir and
+          -winsdkdir. You will likely also want to use
+          --preserve-ms-arch-notation and --disable-symlinks for use with
+          clang-cl on Windows
+
       --map <MAP>
           The path of the filter file that is generated. Defaults to
           ./.xwin-cache/xwin-map.toml

--- a/tests/snapshots/xwin-splat.snap
+++ b/tests/snapshots/xwin-splat.snap
@@ -34,6 +34,13 @@ Options:
           
           Passing this flag will preserve the MS names for those targets.
 
+      --use-winsysroot-style
+          Use the /winsysroot layout, so that clang-cl's /winsysroot flag can be
+          used with the output, rather than needing both -vctoolsdir and
+          -winsdkdir. You will likely also want to use
+          --preserve-ms-arch-notation and --disable-symlinks for use with
+          clang-cl on Windows
+
       --output <OUTPUT>
           The root output directory. Defaults to `./.xwin-cache/splat` if not
           specified


### PR DESCRIPTION
This option changes the layout of the splat a little to support /winsysroot (ref: https://reviews.llvm.org/D95534) which is more convenient when compiling with clang-cl.

Example:
`target\release\xwin --accept-license --arch x86_64 --variant desktop splat --include-debug-libs --include-debug-symbols --preserve-ms-arch-notation --disable-symlinks --use-winsysroot-style --output winsysroot`

Then:
`clang-cl.exe -fuse-ld=lld-link /winsysroot winsysroot src/main.cc`

I didn't realize when I wrote it, but I see this was requested by someone else in Issue #51.