### PR TITLE
Add Earthly support

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,0 +1,3 @@
+**/*
+!xwin.dockerfile
+!Earthfile

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.8
+
+xwin:
+    FROM DOCKERFILE -f xwin.dockerfile /tmp/docker-build
+    SAVE IMAGE xwin:latest


### PR DESCRIPTION
# Motivation

[Earthly](https://earthly.dev) is a tool that allows you to create reliable build systems. It is kind of like a mix of GNUmakefiles and Docker and prides itself as being write once, build everywhere. Earthly can also import Dockerfiles and you can depend on other Earthfiles.

By adding an Earthfile that depends on the Dockerfile, you allow downstream users to import it and follow updates to the Dockerfile without manual intervention required. Like in Github Actions, you can follow branches, tags or commits too.

I use xwin for years now already and, so far, kept my Earthly-based repositories manually up-to-date. I would be very happy if I could automatically update in the future.

# Technical Details

Earthly is very similar to docker buildx and buildkit based. The `.earthlyignore` file uses the same syntax as dockerignore and gitignore and is there to reduce the scope of the build context.

The `Earthfile` can be anywhere inside the repository, as long as the `xwin.dockerfile` is located in the same or a subdirectory of the Earthfile. The build context will always be the same directory as the `Earthfile` and is only affected by the `.earthlyignore` located in the same directory as the `Earthfile`.

So it would be possible to create for example a `docker` folder inside the repository, put the `Earthfile` and `xwin.dockerfile` files inside it, and remove the `.earthlyignore`. That would be equivalent to the way I structured this PR.