### PR TITLE
Earthly requires fully specified refs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,10 @@
 VERSION 0.8
 
+ctx:
+    FROM busybox
+    RUN mkdir -p /tmp/docker-build
+    SAVE ARTIFACT /tmp/docker-build
+
 xwin:
-    FROM DOCKERFILE -f xwin.dockerfile /tmp/docker-build
+    FROM DOCKERFILE -f xwin.dockerfile +ctx/docker-build
     SAVE IMAGE xwin:latest


### PR DESCRIPTION
When importing from a remote repository directly, Earthly turns off a bit of magic and I didn't know that.

I tested this fix using my fork. Sorry about this.