### PR TITLE
Detect case insensitive splat directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#131](https://github.com/Jake-Shadle/xwin/pull/131) resolved [#130](https://github.com/Jake-Shadle/xwin/issues/130) by adding detection of case-insensitive file systems, which then disables symlink creation since it is not needed, and breaks.
+
 ## [0.6.1] - 2024-06-30
 ### Fixed
 - [PR#129](https://github.com/Jake-Shadle/xwin/pull/129) fixed [#128](https://github.com/Jake-Shadle/xwin/issues/128) by adding the additional `onecoreuap` MSI package that contains headers that were previously (before SDK 10.0.26100) part of other MSI packages. Thanks [@bigfoodK](https://github.com/bigfoodK)!


### PR DESCRIPTION
Gotten several reports on splatting failing due to the user using a case-insensitive file system, usually MacOS, so this just adds detection if the directory is on a case-insensitive file system and just disables symlinking automatically since it doesn't matter in that case.

Resolves: #130 