### PR TITLE
Ignore MSI installers with no cabs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       # Add the actual target we compile for in the test
-      - run: rustup target add x86_64-pc-windows-msvc
+      - run: rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
       - name: symlinks
         run: |
           set -eux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#160](https://github.com/Jake-Shadle/xwin/pull/160) resolved [#126](https://github.com/Jake-Shadle/xwin/issues/126) by ignoring MSI installers that don't reference any cabinet files. Why do such utterly fucking useless installers exist? Because fuck me I guess.
+- [PR#159](https://github.com/Jake-Shadle/xwin/pull/159) fixed an issue where enabling native TLS was not actually doing anything. No one actually reported this not working which makes me think no one is using this feature. :)
+
 ## [0.6.6] - 2025-06-19
 ### Fixed
 - [PR#143](https://github.com/Jake-Shadle/xwin/pull/142) is a second attempt to resolve [#141](https://github.com/Jake-Shadle/xwin/issues/141) by switching to a new `3.0.0-rc1` version of ureq that might not have the same issue, as well as adding support for retries for EOF I/O errors seen by users which can be configured via `--http-retry` or `XWIN_HTTP_RETRY`.

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -489,16 +489,17 @@ impl Ctx {
 
         if let Ok(unpack) = std::fs::read(&unpack_dir)
             && let Ok(um) = serde_json::from_slice::<crate::unpack::UnpackMeta>(&unpack)
-                && payload.sha256 == um.sha256 {
-                    tracing::debug!("already unpacked");
-                    unpack_dir.pop();
-                    return Ok(Unpack::Present {
-                        output_dir: unpack_dir,
-                        compressed: um.compressed,
-                        decompressed: um.decompressed,
-                        num_files: um.num_files,
-                    });
-                }
+            && payload.sha256 == um.sha256
+        {
+            tracing::debug!("already unpacked");
+            unpack_dir.pop();
+            return Ok(Unpack::Present {
+                output_dir: unpack_dir,
+                compressed: um.compressed,
+                decompressed: um.decompressed,
+                num_files: um.num_files,
+            });
+        }
 
         unpack_dir.pop();
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -366,6 +366,11 @@ impl Ctx {
                     return Ok(None);
                 }
 
+                let Some(payload_contents) = payload_contents else {
+                    wi.progress.abandon_with_message("MSI with no cabs");
+                    return Ok(None);
+                };
+
                 let ft = crate::unpack::unpack(self.clone(), &wi, payload_contents)?;
 
                 if let crate::Ops::Unpack = ops {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -487,9 +487,9 @@ impl Ctx {
 
         unpack_dir.push(".unpack");
 
-        if let Ok(unpack) = std::fs::read(&unpack_dir) {
-            if let Ok(um) = serde_json::from_slice::<crate::unpack::UnpackMeta>(&unpack) {
-                if payload.sha256 == um.sha256 {
+        if let Ok(unpack) = std::fs::read(&unpack_dir)
+            && let Ok(um) = serde_json::from_slice::<crate::unpack::UnpackMeta>(&unpack)
+                && payload.sha256 == um.sha256 {
                     tracing::debug!("already unpacked");
                     unpack_dir.pop();
                     return Ok(Unpack::Present {
@@ -499,8 +499,6 @@ impl Ctx {
                         num_files: um.num_files,
                     });
                 }
-            }
-        }
 
         unpack_dir.pop();
 

--- a/src/splat.rs
+++ b/src/splat.rs
@@ -408,7 +408,7 @@ pub(crate) fn splat(
             mappings
         }
         PayloadKind::VcrDebug => {
-            if vcrd_version.is_some() {
+            if let Some(version) = vcrd_version {
                 let mut src = src.clone();
                 let mut target = roots.vcrd.clone();
 
@@ -420,7 +420,7 @@ pub(crate) fn splat(
                     });
                 };
 
-                target.push(vcrd_version.unwrap());
+                target.push(version);
                 target.push("bin");
                 target.push(item.payload.target_arch.unwrap().as_str());
 
@@ -588,18 +588,15 @@ pub(crate) fn splat(
                         if !include_debug_libs
                             && (mapping.kind == PayloadKind::CrtLibs
                                 || mapping.kind == PayloadKind::Ucrt)
+                            && let Some(stripped) = fname_str.strip_suffix(".lib")
+                            && (stripped.ends_with('d')
+                                || stripped.ends_with("d_netcore")
+                                || stripped
+                                    .strip_suffix(|c: char| c.is_ascii_digit())
+                                    .is_some_and(|fname| fname.ends_with('d')))
                         {
-                            if let Some(stripped) = fname_str.strip_suffix(".lib") {
-                                if stripped.ends_with('d')
-                                    || stripped.ends_with("d_netcore")
-                                    || stripped
-                                        .strip_suffix(|c: char| c.is_ascii_digit())
-                                        .is_some_and(|fname| fname.ends_with('d'))
-                                {
-                                    tracing::debug!("skipping {fname}");
-                                    continue;
-                                }
-                            }
+                            tracing::debug!("skipping {fname}");
+                            continue;
                         }
 
                         tar.push(fname);

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -177,10 +177,11 @@ pub(crate) fn unpack(
                 }
 
                 if let Some(parent) = fs_path.parent()
-                    && !parent.exists() {
-                        std::fs::create_dir_all(parent)
-                            .with_context(|| format!("unable to create unpack dir '{parent}'"))?;
-                    }
+                    && !parent.exists()
+                {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("unable to create unpack dir '{parent}'"))?;
+                }
 
                 let mut dest = std::fs::File::create(&fs_path).with_context(|| {
                     format!(
@@ -526,9 +527,10 @@ pub(crate) fn unpack(
                         let unpack_path = output_dir.join(&file.name);
 
                         if let Some(parent) = unpack_path.parent()
-                            && !parent.exists() {
-                                std::fs::create_dir_all(parent)?;
-                            }
+                            && !parent.exists()
+                        {
+                            std::fs::create_dir_all(parent)?;
+                        }
 
                         let unpacked_file = std::fs::File::create(&unpack_path)?;
 

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -176,12 +176,11 @@ pub(crate) fn unpack(
                     fs_path.push(comp);
                 }
 
-                if let Some(parent) = fs_path.parent() {
-                    if !parent.exists() {
+                if let Some(parent) = fs_path.parent()
+                    && !parent.exists() {
                         std::fs::create_dir_all(parent)
                             .with_context(|| format!("unable to create unpack dir '{parent}'"))?;
                     }
-                }
 
                 let mut dest = std::fs::File::create(&fs_path).with_context(|| {
                     format!(
@@ -526,11 +525,10 @@ pub(crate) fn unpack(
 
                         let unpack_path = output_dir.join(&file.name);
 
-                        if let Some(parent) = unpack_path.parent() {
-                            if !parent.exists() {
+                        if let Some(parent) = unpack_path.parent()
+                            && !parent.exists() {
                                 std::fs::create_dir_all(parent)?;
                             }
-                        }
 
                         let unpacked_file = std::fs::File::create(&unpack_path)?;
 


### PR DESCRIPTION
At least aarch64, but possibly more, reference MSI installers that don't actually reference any cabinet files. These are utterly fucking worthless, so we just ignore them instead of show an error. VS install is such a garbage fire.

Resolves: #126 