### PR TITLE
Make splatted layout compatible with winsysroot style(fixes #146)

### DIFF
--- a/src/splat.rs
+++ b/src/splat.rs
@@ -274,6 +274,7 @@ pub(crate) fn splat(
                 let mut target = roots.sdk.join("include");
 
                 if config.use_winsysroot_style {
+                    target = roots.sdk.join("Include");
                     target.push(sdk_version);
                 }
 
@@ -295,6 +296,7 @@ pub(crate) fn splat(
             let mut target = roots.sdk.join("lib");
 
             if config.use_winsysroot_style {
+                target = roots.sdk.join("Lib");
                 target.push(sdk_version);
             }
 
@@ -325,6 +327,7 @@ pub(crate) fn splat(
             let mut target = roots.sdk.join("lib");
 
             if config.use_winsysroot_style {
+                target = roots.sdk.join("Lib");
                 target.push(sdk_version);
             }
 
@@ -361,6 +364,7 @@ pub(crate) fn splat(
             } else {
                 let mut target = roots.sdk.join("include");
                 if config.use_winsysroot_style {
+                    target = roots.sdk.join("Include");
                     target.push(sdk_version);
                 }
                 target
@@ -382,6 +386,7 @@ pub(crate) fn splat(
             let mut target = roots.sdk.join("lib");
 
             if config.use_winsysroot_style {
+                target = roots.sdk.join("Lib");
                 target.push(sdk_version);
             }
 


### PR DESCRIPTION
When trying to be compatible with the winsysroot layout, these references ([1](https://github.com/llvm/llvm-project/blob/3fa3e09bdc568db733cf85d020e02e6a8fa0c97f/llvm/cmake/platforms/WinMsvc.cmake#L55C1-L80C57), [2]( https://reviews.llvm.org/D95534), #146), point out that the include and lib subdirectories of the WinSDK should be capitalized.
The current workaround would be to create symlinks, although this requires manual intervention. 

Support for unpack is missing because the `config` and thus the `usewinsysroot` flag are only available in splat.