### PR TITLE
Fix reporting of case-sensitivity

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -324,7 +324,7 @@ impl Ctx {
 
             let enable_symlinks = if std::fs::read(root.join("big.xwin")).is_ok() {
                 tracing::warn!(
-                    "detected splat root '{root}' is on a case-sensitive file system, disabling symlinks"
+                    "detected splat root '{root}' is on a case-insensitive file system, disabling symlinks"
                 );
                 false
             } else {


### PR DESCRIPTION
_I don't think this has ever effected anyone but_ we're creating a file `BIG.xwin`and then checking if its readable via `big.xwin`.
If this is the case we should report that a case-**in**sensitive filesystem is present and not a case-sensitive one.
