### PR TITLE
Install per architecture onecore-uap headers by default too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,6 +747,26 @@ fn get_sdk(
                 variant: None,
                 target_arch: Some(arch),
             });
+
+            let header_payload = sdk.payloads.iter().find(|payload| {
+                payload
+                    .file_name
+                    .strip_prefix("Installers\\Windows SDK OnecoreUap Headers ")
+                    .and_then(|fname| fname.strip_suffix("-x86_en-us.msi"))
+                    .is_some_and(|fname| fname == arch.as_ms_str())
+            });
+            if let Some(header_payload) = header_payload {
+                pruned.push(Payload {
+                    filename: format!("{}_{}_uap_headers.msi", sdk.id, arch.as_ms_str()).into(),
+                    sha256: header_payload.sha256.clone(),
+                    url: header_payload.url.clone(),
+                    size: header_payload.size,
+                    install_size: None,
+                    kind: PayloadKind::SdkHeaders,
+                    variant: None,
+                    target_arch: Some(arch),
+                });
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -751,7 +751,8 @@ fn get_sdk(
             let header_payload = sdk.payloads.iter().find(|payload| {
                 payload
                     .file_name
-                    .strip_prefix("Installers\\Windows SDK OnecoreUap Headers ")
+                    .strip_prefix("Installers")
+                    .and_then(|fname| fname[1..].strip_prefix("Windows SDK OnecoreUap Headers "))
                     .and_then(|fname| fname.strip_suffix("-x86_en-us.msi"))
                     .is_some_and(|fname| fname == arch.as_ms_str())
             });


### PR DESCRIPTION
Starting 10.0.26100.0, some headers previously part of regular SDK headers been splitted into separate packages. #134 added the x86-x86 one which contains majority of headers but appearantly there are arch-specific packages too.

For x64 there's:

```
Program Files/Windows Kits/10/Include/10.0.26100.0/shared/ksamd64.inc
```

For arm64 there are:

```
Program Files/Windows Kits/10/Include/10.0.26100.0/shared/ksarm64.h
Program Files/Windows Kits/10/Include/10.0.26100.0/shared/kxarm64.h
Program Files/Windows Kits/10/Include/10.0.26100.0/shared/kxarm64unw.h
```

I came up with this trying to build cryptopp without CRYPTOPP_DISABLE_ASM=1, it tries to include ksamd64.inc.